### PR TITLE
Reverse the board so it displays correctly

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -109,7 +109,7 @@ impl ChessBoard{
 	pub fn display(&self){
 		println!(" | A| B| C| D| E| F| G| H|");
 		println!("--------------------------");
-		for (row, num) in self.board.iter().zip(0u8 .. 8){
+		for (row, num) in self.board.iter().zip(0u8 .. 8).rev(){
 			print!("{}|", num + 1);
 			for tile in row.iter(){
 				print!("{}|", tile.display());


### PR DESCRIPTION
The ranks of the board are numbered from the bottom. Because of this, we
have to print the rows of the board in reverse order, or else the board
will be displayed inversed vertically.
